### PR TITLE
DOCS: 통계 및 정산 배치 프로세스

### DIFF
--- a/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/StatisticsBatch.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/StatisticsBatch.java
@@ -1,0 +1,377 @@
+package org.streaming.revenuemanagement.domain.adjustment.batch;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.RepositoryItemWriter;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.batch.item.data.builder.RepositoryItemWriterBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Transactional;
+import org.streaming.revenuemanagement.domain.videodailystatistics.entity.VideoDailyStatistics;
+import org.streaming.revenuemanagement.domain.videodailystatistics.repository.VideoDailyStatisticsRepository;
+import org.streaming.revenuemanagement.domain.videolog.dto.VideoLogStatisticsRespDto;
+import org.streaming.revenuemanagement.domain.videolog.repository.VideoLogRepository;
+import org.streaming.revenuemanagement.domain.videostatistics.entity.VideoStatistics;
+import org.streaming.revenuemanagement.domain.videostatistics.repository.VideoStatisticsRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class StatisticsBatch {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager platformTransactionManager;
+
+    private final VideoLogRepository videoLogRepository;
+    private final VideoStatisticsRepository videoStatisticsRepository;
+    private final VideoDailyStatisticsRepository videoDailyStatisticsRepository;
+
+    @Value("${spring.batch.chunk.size}")
+    private int chunkSize;
+
+    @Bean
+    public Job statisticsJob() {
+
+        return new JobBuilder("statisticsJob", jobRepository)
+                .start(statisticsStep1())
+                .next(statisticsStep2())
+                .next(statisticsStep3())
+                .next(adjustmentStep1())
+                .build();
+    }
+
+    // Step1: VideoStatistics 별로 전날 조회수, 광고 조회수, 재생시간, 정산 데이터를 집계할 VideoDailyStatistics 객체 생성
+    @Bean
+    public Step statisticsStep1() {
+
+        return new StepBuilder("statisticsStep1", jobRepository)
+                .<VideoStatistics, VideoDailyStatistics> chunk(chunkSize, platformTransactionManager)
+                .reader(videoStatisticsReader())
+                .processor(videoStatisticsProcessor())
+                .writer(videoDailyStatisticsWriter())
+                .build();
+    }
+
+    @Bean
+    public RepositoryItemReader<VideoStatistics> videoStatisticsReader() {
+
+        return new RepositoryItemReaderBuilder<VideoStatistics>()
+                .name("videoStatisticsReader")
+                .pageSize(chunkSize)
+                .methodName("findAll")
+                .repository(videoStatisticsRepository)
+                .sorts(Map.of("id", Sort.Direction.ASC))
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<VideoStatistics, VideoDailyStatistics> videoStatisticsProcessor() {
+
+        return new ItemProcessor<VideoStatistics, VideoDailyStatistics>() {
+
+            @Override
+            public VideoDailyStatistics process(VideoStatistics videoStatistics) throws Exception {
+
+                return VideoDailyStatistics.builder()
+                        .videoStatistics(videoStatistics)
+                        .videoId(videoStatistics.getVideo().getId())
+                        .build();
+            }
+        };
+    }
+
+    @Bean
+    public RepositoryItemWriter<VideoDailyStatistics> videoDailyStatisticsWriter() {
+
+        return new RepositoryItemWriterBuilder<VideoDailyStatistics>()
+                .repository(videoDailyStatisticsRepository)
+                .methodName("save")
+                .build();
+    }
+
+
+    // Step2: VideoLog 데이터를 가지고 VideoDailyStatistics에 쌓는 단계
+    @Bean
+    public Step statisticsStep2() {
+
+        return new StepBuilder("statisticsStep2", jobRepository)
+                .<VideoLogStatisticsRespDto, VideoDailyStatistics> chunk(chunkSize, platformTransactionManager)
+                .reader(videoLogStatisticsReader())
+                .processor(videoLogStatisticsProcessor())
+                .writer(videoLogVideoDailyStatisticsWriter())
+                .build();
+    }
+
+    // 청크 사이즈 별로 VideoLog 데이터를 읽어와서 같은 영상에 대한 조회수, 광고 조회수, 재생시간 합계해 DTO로 반환
+    @Bean
+    public RepositoryItemReader<VideoLogStatisticsRespDto> videoLogStatisticsReader() {
+
+        LocalDateTime startOfYesterday = LocalDateTime.now().minusDays(1).withHour(0).withMinute(0).withSecond(0);
+        LocalDateTime endOfYesterday = LocalDateTime.now().minusDays(1).withHour(23).withMinute(59).withSecond(59);
+
+        return new RepositoryItemReaderBuilder<VideoLogStatisticsRespDto>()
+                .name("videoLogStatisticsReader")
+                .arguments(List.of(startOfYesterday, endOfYesterday))
+                .pageSize(chunkSize)
+                .methodName("findVideoStatisticsBetweenDates")
+                .repository(videoLogRepository)
+                .sorts(Map.of())  // 정렬 필요 없음
+                .build();
+    }
+
+    // 각 비디오의 VideoDailyStatistics에 조회수, 광고 조회수, 재생시간 업데이트
+    @Bean
+    public ItemProcessor<VideoLogStatisticsRespDto, VideoDailyStatistics> videoLogStatisticsProcessor() {
+
+        return new ItemProcessor<VideoLogStatisticsRespDto, VideoDailyStatistics>() {
+            @Override
+            public VideoDailyStatistics process(VideoLogStatisticsRespDto item) throws Exception {
+                Long videoId = item.getVideoId();
+                Long views = item.getViews();
+                Long adViews = item.getAdViews();
+                Long playTime = item.getPlayTime();
+
+                VideoDailyStatistics videoDailyStatistics = videoDailyStatisticsRepository.findByVideoId(videoId)
+                        .orElseGet(() -> VideoDailyStatistics.builder()
+                                .videoId(videoId)
+                                .build());
+
+                // 기존 데이터에 새로운 통계 정보 업데이트
+                videoDailyStatistics.updateStatistics(views, adViews, playTime);
+                return videoDailyStatistics;
+            }
+        };
+    }
+
+    // 그리고 VideoDailyStatistics들을 saveAll
+    @Bean
+    public ItemWriter<VideoDailyStatistics> videoLogVideoDailyStatisticsWriter() {
+
+        return new ItemWriter<VideoDailyStatistics>() {
+            @Override
+            public void write(Chunk<? extends VideoDailyStatistics> chunk) throws Exception {
+                // 데이터베이스에 일괄 저장
+                videoDailyStatisticsRepository.saveAll(chunk.getItems());
+            }
+        };
+    }
+
+    // Step3: VideoDailyStatistics 데이터를 통해 누적 합산 엔티티인 VideoStatistics 업데이트
+    @Bean
+    public Step statisticsStep3() {
+
+        return new StepBuilder("statisticsStep3", jobRepository)
+                .<VideoDailyStatistics, VideoStatistics> chunk(chunkSize, platformTransactionManager)
+                .reader(videoDailyStatisticsReader())
+                .processor(videoDailyStatisticsProcessor())
+                .writer(videoStatisticsWriter())
+                .build();
+    }
+
+    // 당일 생성된 VideoDailyStatistics를 찾아옴
+    @Bean
+    public RepositoryItemReader<VideoDailyStatistics> videoDailyStatisticsReader() {
+
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+
+        return new RepositoryItemReaderBuilder<VideoDailyStatistics>()
+                .name("videoDailyStatisticsReader")
+                .arguments(List.of(startOfDay, endOfDay)) // 날짜 범위와 페이징 정보 전달
+                .pageSize(chunkSize)
+                .methodName("findAllByCreatedAtBetween")
+                .repository(videoDailyStatisticsRepository)
+                .sorts(Map.of("id", Sort.Direction.ASC))
+                .build();
+    }
+
+    // videoStatistics에 조회수, 광고 조회수, 재생시간 누적 합산 업데이트
+    @Bean
+    public ItemProcessor<VideoDailyStatistics, VideoStatistics> videoDailyStatisticsProcessor() {
+
+        return new ItemProcessor<VideoDailyStatistics, VideoStatistics>() {
+
+            @Override
+            public VideoStatistics process(VideoDailyStatistics videoDailyStatistics) throws Exception {
+
+                VideoStatistics videoStatistics = videoStatisticsRepository.findById(videoDailyStatistics.getVideoStatistics().getId()).orElseThrow();
+                videoStatistics.updateStatistics(videoDailyStatistics.getDailyViews(), videoDailyStatistics.getDailyAdViews(), videoDailyStatistics.getDailyPlayTime());
+
+                return videoStatistics;
+            }
+        };
+    }
+
+    @Bean
+    public RepositoryItemWriter<VideoStatistics> videoStatisticsWriter() {
+
+        return new RepositoryItemWriterBuilder<VideoStatistics>()
+                .repository(videoStatisticsRepository)
+                .methodName("save")
+                .build();
+    }
+
+    // Step4: 정산 작업을 수행하는 단계
+    @Bean
+    public Step adjustmentStep1() {
+
+        return new StepBuilder("adjustmentStep1", jobRepository)
+                .<VideoDailyStatistics, VideoDailyStatistics> chunk(chunkSize, platformTransactionManager)
+                .reader(adjustmentVideoDailyStatisticsReader())
+                .processor(adjustmentVideoDailyStatisticsProcessor())
+                .writer(adjustmentVideoDailyStatisticsWriter())
+                .build();
+    }
+
+    @Bean
+    public RepositoryItemReader<VideoDailyStatistics> adjustmentVideoDailyStatisticsReader() {
+
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay(); // 오늘 00:00:00
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX); // 오늘 23:59:59
+
+        return new RepositoryItemReaderBuilder<VideoDailyStatistics>()
+                .name("adjustmentVideoDailyStatisticsReader")
+                .arguments(List.of(startOfDay, endOfDay))
+                .pageSize(chunkSize)
+                .methodName("findAllByCreatedAtBetween")
+                .repository(videoDailyStatisticsRepository)
+                .sorts(Map.of("id", Sort.Direction.ASC))
+                .build();
+    }
+
+    // 당일 생성된 VideoDailyStatistics의 데이터들을 기반으로 단가를 계산하고 업데이트
+    @Bean
+    public ItemProcessor<VideoDailyStatistics, VideoDailyStatistics> adjustmentVideoDailyStatisticsProcessor() {
+
+        return new ItemProcessor<VideoDailyStatistics, VideoDailyStatistics>() {
+
+            @Override
+            public VideoDailyStatistics process(VideoDailyStatistics videoDailyStatistics) throws Exception {
+
+                VideoStatistics videoStatistics = videoDailyStatistics.getVideoStatistics();
+                long totalViews = videoStatistics.getTotalViews() + videoDailyStatistics.getDailyViews();
+                long dailyViews = videoDailyStatistics.getDailyViews();
+                long dailyAdViews = videoDailyStatistics.getDailyAdViews();
+
+                // 영상별 단가 계산
+                long videoAdjustment = calculateViewAdjustment(totalViews, dailyViews);
+
+                // 광고별 단가 계산
+                long adAdjustment = calculateAdAdjustment(totalViews, dailyAdViews);
+
+                // 단가 계산 후 조회수 정산 및 광고 조회수 정산 비용 업데이트
+                videoDailyStatistics.updateAdjustment(videoAdjustment);
+                videoDailyStatistics.updateAdAdjustment(adAdjustment);
+
+                videoStatistics.updateAdjustment(videoAdjustment);
+                videoStatistics.updateAdAdjustment(adAdjustment);
+
+                return videoDailyStatistics;
+            }
+
+            // 요구사항대로 단가 계산하는 메서드
+            private long calculateViewAdjustment(long totalViews, long dailyViews) {
+                long adjustment = 0;
+
+                if (totalViews < 100_000) {
+                    adjustment += Math.min(100_000 - totalViews, dailyViews) * 1;
+                    dailyViews -= Math.min(100_000 - totalViews, dailyViews);
+                    totalViews = Math.min(100_000, totalViews + dailyViews);
+                }
+
+                if (totalViews >= 100_000 && totalViews < 500_000 && dailyViews > 0) {
+                    adjustment += Math.min(500_000 - totalViews, dailyViews) * 1.1;
+                    dailyViews -= Math.min(500_000 - totalViews, dailyViews);
+                    totalViews = Math.min(500_000, totalViews + dailyViews);
+                }
+
+                if (totalViews >= 500_000 && totalViews < 1_000_000 && dailyViews > 0) {
+                    adjustment += Math.min(1_000_000 - totalViews, dailyViews) * 1.3;
+                    dailyViews -= Math.min(1_000_000 - totalViews, dailyViews);
+                    totalViews = Math.min(1_000_000, totalViews + dailyViews);
+                }
+
+                if (totalViews >= 1_000_000 && dailyViews > 0) {
+                    adjustment += dailyViews * 1.5;
+                }
+
+                return (long) Math.floor(adjustment); // 1원 단위 이하 절사
+            }
+
+            private long calculateAdAdjustment(long totalViews, long dailyAdViews) {
+                long adjustment = 0;
+
+                if (totalViews < 100_000) {
+                    adjustment += Math.min(100_000 - totalViews, dailyAdViews) * 10;
+                    dailyAdViews -= Math.min(100_000 - totalViews, dailyAdViews);
+                    totalViews = Math.min(100_000, totalViews + dailyAdViews);
+                }
+
+                if (totalViews >= 100_000 && totalViews < 500_000 && dailyAdViews > 0) {
+                    adjustment += Math.min(500_000 - totalViews, dailyAdViews) * 12;
+                    dailyAdViews -= Math.min(500_000 - totalViews, dailyAdViews);
+                    totalViews = Math.min(500_000, totalViews + dailyAdViews);
+                }
+
+                if (totalViews >= 500_000 && totalViews < 1_000_000 && dailyAdViews > 0) {
+                    adjustment += Math.min(1_000_000 - totalViews, dailyAdViews) * 15;
+                    dailyAdViews -= Math.min(1_000_000 - totalViews, dailyAdViews);
+                    totalViews = Math.min(1_000_000, totalViews + dailyAdViews);
+                }
+
+                if (totalViews >= 1_000_000 && dailyAdViews > 0) {
+                    adjustment += dailyAdViews * 20;
+                }
+
+                return (long) Math.floor(adjustment); // 1원 단위 이하 절사
+            }
+        };
+    }
+
+    // VideoDailyStatistics 및 VideoStatistics를 모두 저장
+    @Bean
+    public ItemWriter<VideoDailyStatistics> adjustmentVideoDailyStatisticsWriter() {
+        return items -> {
+            List<VideoDailyStatistics> updatedVideoDailyStatistics = new ArrayList<>();
+            List<VideoStatistics> updatedVideoStatistics = new ArrayList<>();
+
+            for (VideoDailyStatistics dailyStatistics : items) {
+
+                updatedVideoDailyStatistics.add(dailyStatistics);
+
+                VideoStatistics videoStatistics = dailyStatistics.getVideoStatistics();
+                updatedVideoStatistics.add(videoStatistics);
+            }
+
+            saveAllVideoData(updatedVideoDailyStatistics, updatedVideoStatistics);
+        };
+    }
+
+    // 두 개의 Repository를 사용하여 데이터를 한 번에 저장
+    @Transactional
+    public void saveAllVideoData(List<VideoDailyStatistics> videoDailyStatisticsList, List<VideoStatistics> videoStatisticsList) {
+        // VideoDailyStatistics와 VideoStatistics를 모두 한 번에 저장
+        videoDailyStatisticsRepository.saveAll(videoDailyStatisticsList);
+        videoStatisticsRepository.saveAll(videoStatisticsList);
+    }
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/videodailystatistics/entity/VideoDailyStatistics.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/videodailystatistics/entity/VideoDailyStatistics.java
@@ -1,0 +1,65 @@
+package org.streaming.revenuemanagement.domain.videodailystatistics.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.streaming.revenuemanagement.domain.global.entity.BaseEntity;
+import org.streaming.revenuemanagement.domain.videostatistics.entity.VideoStatistics;
+
+@Entity
+@Table
+@Getter
+@NoArgsConstructor
+public class VideoDailyStatistics extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "video_statistics_id")
+    private VideoStatistics videoStatistics;
+
+    @Column(nullable = false)
+    private Long videoId;
+
+    @Column(nullable = false)
+    private Long dailyViews = 0L;
+
+    @Column(nullable = false)
+    private Long dailyAdViews = 0L;
+
+    @Column(nullable = false)
+    private Long dailyPlayTime = 0L;
+
+    @Column(nullable = false)
+    private Long dailyAdjustment = 0L;
+
+    @Column(nullable = false)
+    private Long dailyAdAdjustment = 0L;
+
+    @Builder
+    public VideoDailyStatistics(VideoStatistics videoStatistics, Long videoId) {
+
+        this.videoStatistics = videoStatistics;
+        this.videoId = videoId;
+    }
+
+    public void updateStatistics(Long views, Long adViews, Long playTime) {
+
+        this.dailyViews += views;
+        this.dailyAdViews += adViews;
+        this.dailyPlayTime += playTime;
+    }
+
+    public void updateAdjustment(Long adjustment) {
+
+        this.dailyAdjustment += adjustment;
+    }
+
+    public void updateAdAdjustment(Long adAdjustment) {
+
+        this.dailyAdAdjustment += adAdjustment;
+    }
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/videodailystatistics/repository/VideoDailyStatisticsRepository.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/videodailystatistics/repository/VideoDailyStatisticsRepository.java
@@ -1,0 +1,47 @@
+package org.streaming.revenuemanagement.domain.videodailystatistics.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.streaming.revenuemanagement.domain.videodailystatistics.dto.VideoStatisticDto;
+import org.streaming.revenuemanagement.domain.videodailystatistics.entity.VideoDailyStatistics;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface VideoDailyStatisticsRepository extends JpaRepository<VideoDailyStatistics, Long> {
+
+    Optional<VideoDailyStatistics> findByVideoId(Long videoId);
+
+    // 특정 기간 동안 생성된 VideoDailyStatistics 엔티티들을 페이징 형식으로 조회
+    Page<VideoDailyStatistics> findAllByCreatedAtBetween(LocalDateTime start, LocalDateTime end, Pageable pageable);
+
+    // 조회수가 높은 TOP 5 동영상 가져오기
+    // VideoStatisticDto 객체로 비디오 ID와 조회수 합계를 반환하며, 조회수를 기준으로 내림차순으로 정렬
+    @Query("SELECT new org.streaming.revenuemanagement.domain.videodailystatistics.dto.VideoStatisticDto(v.videoId, SUM(v.dailyViews)) " +
+            "FROM VideoDailyStatistics v " +
+            "WHERE v.createdAt BETWEEN :start AND :end " +
+            "GROUP BY v.videoId " +
+            "ORDER BY SUM(v.dailyViews) DESC")
+    List<VideoStatisticDto> findTop5ByViews(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            Pageable pageable);
+
+    // 재생 시간이 긴 TOP 5 동영상 가져오기
+    // VideoStatisticDto 객체로 비디오 ID와 재생 시간 합계를 반환하며, 재생 시간을 기준으로 내림차순으로 정렬
+    @Query("SELECT new org.streaming.revenuemanagement.domain.videodailystatistics.dto.VideoStatisticDto(v.videoId, SUM(v.dailyPlayTime)) " +
+            "FROM VideoDailyStatistics v " +
+            "WHERE v.createdAt BETWEEN :start AND :end " +
+            "GROUP BY v.videoId " +
+            "ORDER BY SUM(v.dailyPlayTime) DESC")
+    List<VideoStatisticDto> findTop5ByPlayTime(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            Pageable pageable);
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/videolog/repository/VideoLogRepository.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/videolog/repository/VideoLogRepository.java
@@ -1,0 +1,29 @@
+package org.streaming.revenuemanagement.domain.videolog.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.streaming.revenuemanagement.domain.videolog.dto.VideoLogStatisticsRespDto;
+import org.streaming.revenuemanagement.domain.videolog.entity.VideoLog;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+public interface VideoLogRepository extends JpaRepository<VideoLog, Long> {
+
+    // 특정 비디오 ID와 회원 ID에 대한 가장 최근의 VideoLog를 조회
+    Optional<VideoLog> findFirstByVideoIdAndMemberIdOrderByIdDesc(Long videoId, Long memberId);
+
+    // 특정 기간 동안의 비디오 통계를 조회하여 VideoLogStatisticsRespDto 객체로 반환
+    // 비디오별로 광고 수(adCnt), 재생 시간(playTime), 그리고 로그 개수를 그룹화하여 통계 제공
+    @Query("SELECT new org.streaming.revenuemanagement.domain.videolog.dto.VideoLogStatisticsRespDto(v.video.id, COUNT(v), SUM(v.adCnt), SUM(v.playTime)) " +
+            "FROM VideoLog v " +
+            "WHERE v.createdAt BETWEEN :start AND :end " +
+            "GROUP BY v.video.id")
+    Page<VideoLogStatisticsRespDto> findVideoStatisticsBetweenDates(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end, Pageable pageable);
+
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/videostatistics/entity/VideoStatistics.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/videostatistics/entity/VideoStatistics.java
@@ -1,0 +1,56 @@
+package org.streaming.revenuemanagement.domain.videostatistics.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.streaming.revenuemanagement.domain.global.entity.BaseEntity;
+import org.streaming.revenuemanagement.domain.video.entity.Video;
+
+@Entity
+@Table
+@Getter
+@NoArgsConstructor
+public class VideoStatistics extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "video_id")
+    private Video video;
+
+    @Column(nullable = false)
+    private Long totalViews = 0L;
+
+    @Column(nullable = false)
+    private Long totalAdViews = 0L;
+
+    @Column(nullable = false)
+    private Long totalPlayTime = 0L;
+
+    @Column(nullable = false)
+    private Long totalAdjustment = 0L;
+
+    @Column(nullable = false)
+    private Long totalAdAdjustment = 0L;
+
+
+    public void updateStatistics(Long totalViews, Long totalAdViews, Long totalPlayTime) {
+
+        this.totalViews += totalViews;
+        this.totalAdViews += totalAdViews;
+        this.totalPlayTime += totalPlayTime;
+    }
+
+    public void updateAdjustment(Long totalAdjustment) {
+
+        this.totalAdjustment += totalAdjustment;
+    }
+
+    public void updateAdAdjustment(Long totalAdAdjustment) {
+
+        this.totalAdAdjustment += totalAdAdjustment;
+    }
+
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/videostatistics/repository/VideoStatisticsRepository.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/videostatistics/repository/VideoStatisticsRepository.java
@@ -1,0 +1,25 @@
+package org.streaming.revenuemanagement.domain.videostatistics.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.streaming.revenuemanagement.domain.videostatistics.dto.AdjustmentStatisticDto;
+import org.streaming.revenuemanagement.domain.videostatistics.entity.VideoStatistics;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface VideoStatisticsRepository extends JpaRepository<VideoStatistics, Long> {
+
+    // 특정 비디오 ID와 기간을 기준으로 정산 통계 정보를 조회하는 쿼리 메서드
+    // 데이터 전체가 아닌 비디오 아이디, 총 조회수 정산, 총 광고 조회수 정산 데이터만 DTO로 반환받음
+    @Query("SELECT new org.streaming.revenuemanagement.domain.videostatistics.dto.AdjustmentStatisticDto(v.video.id, v.totalAdjustment, v.totalAdAdjustment) " +
+            "FROM VideoStatistics v " +
+            "WHERE v.video.id = :videoId AND v.createdAt BETWEEN :start AND :end")
+    List<AdjustmentStatisticDto> findAdjustmentStatisticsByVideoIdAndDateRange(@Param("videoId") Long videoId,
+                                                                               @Param("start") LocalDateTime start,
+                                                                               @Param("end") LocalDateTime end);
+
+}


### PR DESCRIPTION
- statisticsJob 배치 잡 추가
  - Step1: VideoStatistics 데이터를 기반으로 VideoDailyStatistics 엔티티 생성
  - Step2: VideoLog 데이터를 VideoDailyStatistics에 집계하여 업데이트
  - Step3: VideoDailyStatistics 데이터를 기반으로 VideoStatistics 누적 업데이트
  - Step4: 정산 작업(adjustment)을 통해 단가 계산 및 정산 데이터 업데이트

- VideoLog 데이터 기반으로 조회수, 광고 조회수, 재생시간 통계 생성
  - statisticsStep2에서 VideoLogStatisticsRespDto를 통해 VideoDailyStatistics에 데이터 집계

- 정산 단가 계산 로직 추가
  - adjustmentStep1에서 VideoDailyStatistics의 조회수와 광고 조회수를 기반으로 단가 계산
  - VideoStatistics와 VideoDailyStatistics의 정산 금액 필드 업데이트

- VideoDailyStatistics와 VideoStatistics 저장 로직 추가
  - 각 Step에서 수정된 데이터 저장
  - adjustmentVideoDailyStatisticsWriter에서 관련된 VideoDailyStatistics와 VideoStatistics 저장 처리