### PR TITLE
Review: 코드리뷰

### DIFF
--- a/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/BatchScheduler.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/BatchScheduler.java
@@ -1,0 +1,45 @@
+package org.streaming.revenuemanagement.domain.adjustment.batch;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class BatchScheduler {
+
+    private final JobLauncher jobLauncher;
+
+    @Qualifier("statisticsJob")
+    private final Job statisticsJob;
+
+    public BatchScheduler(JobLauncher jobLauncher,
+                          @Qualifier("statisticsJob") Job statisticsJob) {
+        this.jobLauncher = jobLauncher;
+        this.statisticsJob = statisticsJob;
+    }
+
+    @Scheduled(cron = "00 46 02 * * *")
+    public void runStatisticsJob() {
+        try {
+            // 어제의 시작 날짜와 종료 날짜 정의
+            LocalDateTime startDate = LocalDateTime.now().minusDays(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
+            LocalDateTime endDate = LocalDateTime.now().minusDays(1).withHour(23).withMinute(59).withSecond(59).withNano(0);
+
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addLong("currentTime", System.currentTimeMillis()) // 매 실행 시 유니크한 파라미터 추가 (중복 방지용)
+                    .addString("startDate", startDate.toString()) // 어제의 시작 날짜 파라미터 추가
+                    .addString("endDate", endDate.toString()) // 어제의 종료 날짜 파라미터 추가
+                    .toJobParameters();
+
+            jobLauncher.run(statisticsJob, jobParameters);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/StatisticsBatch.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/StatisticsBatch.java
@@ -1,0 +1,140 @@
+package org.streaming.revenuemanagement.domain.adjustment.batch;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.streaming.revenuemanagement.domain.adjustment.batch.processor.AdjustmentVideoDailyStatisticsProcessor;
+import org.streaming.revenuemanagement.domain.adjustment.batch.processor.VideoDailyStatisticsProcessor;
+import org.streaming.revenuemanagement.domain.adjustment.batch.processor.VideoLogStatisticsProcessor;
+import org.streaming.revenuemanagement.domain.adjustment.batch.processor.VideoStatisticsProcessor;
+import org.streaming.revenuemanagement.domain.adjustment.batch.reader.AdjustmentVideoDailyStatisticsReader;
+import org.streaming.revenuemanagement.domain.adjustment.batch.reader.VideoDailyStatisticsReader;
+import org.streaming.revenuemanagement.domain.adjustment.batch.reader.VideoStatisticsReader;
+import org.streaming.revenuemanagement.domain.adjustment.batch.writer.AdjustmentVideoDailyStatisticsWriter;
+import org.streaming.revenuemanagement.domain.adjustment.batch.writer.VideoDailyStatisticsWriter;
+import org.streaming.revenuemanagement.domain.adjustment.batch.writer.VideoStatisticsWriter;
+import org.streaming.revenuemanagement.domain.videodailystatistics.entity.VideoDailyStatistics;
+import org.streaming.revenuemanagement.domain.videolog.entity.VideoLog;
+import org.streaming.revenuemanagement.domain.videolog.repository.VideoLogRepository;
+import org.streaming.revenuemanagement.domain.videostatistics.entity.VideoStatistics;
+
+@Configuration
+@RequiredArgsConstructor
+public class StatisticsBatch {
+
+    private final JobRepository jobRepository;
+    private final VideoLogRepository videoLogRepository;
+    private final PlatformTransactionManager platformTransactionManager;
+
+    private final VideoStatisticsReader videoStatisticsReader;
+
+    private final RepositoryItemReader<VideoLog> videoLogPartitionReaderMethod;
+    private final VideoDailyStatisticsReader videoDailyStatisticsReader;
+    private final AdjustmentVideoDailyStatisticsReader adjustmentVideoDailyStatisticsReader;
+
+    private final VideoStatisticsProcessor videoStatisticsProcessor;
+    private final VideoLogStatisticsProcessor videoLogStatisticsProcessor;
+    private final VideoDailyStatisticsProcessor videoDailyStatisticsProcessor;
+    private final AdjustmentVideoDailyStatisticsProcessor adjustmentVideoDailyStatisticsProcessor;
+
+    private final VideoDailyStatisticsWriter videoDailyStatisticsWriter;
+    private final VideoStatisticsWriter videoStatisticsWriter;
+    private final AdjustmentVideoDailyStatisticsWriter adjustmentVideoDailyStatisticsWriter;
+
+    @Value("${spring.batch.chunk.size}")
+    private int chunkSize;
+
+    @Value("${spring.batch.pool.size}")
+    private int pool;
+
+    @Bean(name = "statisticsJob_taskPool")
+    public TaskExecutor executor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(pool);
+        executor.setMaxPoolSize(pool);
+        executor.setThreadNamePrefix("partition-thread");
+        executor.setWaitForTasksToCompleteOnShutdown(Boolean.TRUE);
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean(name = "statisticsJob_partitioner")
+    @JobScope
+    public VideoStatisticsPartitioner partitioner(
+            @Value("#{jobParameters['startDate']}") String startDate,
+            @Value("#{jobParameters['endDate']}") String endDate
+    ) {
+        return new VideoStatisticsPartitioner(videoLogRepository, startDate, endDate);
+    }
+
+    @Bean
+    public Job statisticsJob() {
+        return new JobBuilder("statisticsJob", jobRepository)
+                .start(statisticsStep1())
+                .next(step2Manager())
+                .next(statisticsStep3())
+                .next(adjustmentStep1())
+                .build();
+    }
+
+    @Bean
+    public Step statisticsStep1() {
+        return new StepBuilder("statisticsStep1", jobRepository)
+                .<VideoStatistics, VideoDailyStatistics>chunk(chunkSize, platformTransactionManager)
+                .reader(videoStatisticsReader.reader(chunkSize))
+                .processor(videoStatisticsProcessor)
+                .writer(videoDailyStatisticsWriter)
+                .build();
+    }
+
+    @Bean
+    public Step step2Manager() {
+        return new StepBuilder("statisticsStep2.manager", jobRepository)
+                .partitioner("statisticsStep2", partitioner(null, null))
+                .gridSize(pool)
+                .step(statisticsStep2())
+                .taskExecutor(executor())
+                .build();
+    }
+
+    @Bean
+    public Step statisticsStep2() {
+        return new StepBuilder("statisticsStep2", jobRepository)
+                .<VideoLog, VideoDailyStatistics>chunk(chunkSize, platformTransactionManager)
+                .reader(videoLogPartitionReaderMethod)
+                .processor(videoLogStatisticsProcessor)
+                .writer(videoDailyStatisticsWriter)
+                .build();
+    }
+
+    @Bean
+    public Step statisticsStep3() {
+        return new StepBuilder("statisticsStep3", jobRepository)
+                .<VideoDailyStatistics, VideoStatistics>chunk(chunkSize, platformTransactionManager)
+                .reader(videoDailyStatisticsReader.reader(chunkSize))
+                .processor(videoDailyStatisticsProcessor)
+                .writer(videoStatisticsWriter)
+                .build();
+    }
+
+    @Bean
+    public Step adjustmentStep1() {
+        return new StepBuilder("adjustmentStep1", jobRepository)
+                .<VideoDailyStatistics, VideoDailyStatistics>chunk(chunkSize, platformTransactionManager)
+                .reader(adjustmentVideoDailyStatisticsReader.reader(chunkSize))
+                .processor(adjustmentVideoDailyStatisticsProcessor)
+                .writer(adjustmentVideoDailyStatisticsWriter)
+                .build();
+    }
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/VideoStatisticsPartitioner.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/VideoStatisticsPartitioner.java
@@ -1,0 +1,56 @@
+package org.streaming.revenuemanagement.domain.adjustment.batch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.partition.support.Partitioner;
+import org.springframework.batch.item.ExecutionContext;
+import org.streaming.revenuemanagement.domain.videolog.repository.VideoLogRepository;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+public class VideoStatisticsPartitioner implements Partitioner {
+
+    private final VideoLogRepository videoLogRepository;
+    private final String startDateStr;
+    private final String endDateStr;
+
+    @Override
+    public Map<String, ExecutionContext> partition(int gridSize) {
+        LocalDateTime startDate = LocalDateTime.parse(startDateStr, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        LocalDateTime endDate = LocalDateTime.parse(endDateStr, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+
+        long min = videoLogRepository.findMinId(startDate, endDate);
+        long max = videoLogRepository.findMaxId(startDate, endDate);
+
+        log.info("VideoStatisticsPartitioner min = {}, max = {}", min, max);
+
+        long targetSize = (max - min) / gridSize + 1;
+
+        Map<String, ExecutionContext> result = new HashMap<>();
+        long number = 0;
+        long start = min;
+        long end = start + targetSize - 1;
+
+        while (start <= max) {
+            ExecutionContext value = new ExecutionContext();
+            result.put("partition" + number, value);
+
+            if (end >= max) {
+                end = max;
+            }
+
+            value.putLong("minId", start); // 각 파티션마다 사용될 minId
+            value.putLong("maxId", end); // 각 파티션마다 사용될 maxId
+            start += targetSize;
+            end += targetSize;
+            number++;
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/processor/AdjustmentVideoDailyStatisticsProcessor.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/processor/AdjustmentVideoDailyStatisticsProcessor.java
@@ -1,0 +1,76 @@
+package org.streaming.revenuemanagement.domain.adjustment.batch.processor;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+import org.streaming.revenuemanagement.domain.videodailystatistics.entity.VideoDailyStatistics;
+import org.streaming.revenuemanagement.domain.videostatistics.entity.VideoStatistics;
+
+@Component
+@RequiredArgsConstructor
+public class AdjustmentVideoDailyStatisticsProcessor implements ItemProcessor<VideoDailyStatistics, VideoDailyStatistics> {
+
+    @Override
+    public VideoDailyStatistics process(VideoDailyStatistics videoDailyStatistics) throws Exception {
+        VideoStatistics videoStatistics = videoDailyStatistics.getVideoStatistics();
+        long totalViews = videoStatistics.getTotalViews() + videoDailyStatistics.getDailyViews();
+        long dailyViews = videoDailyStatistics.getDailyViews();
+        long dailyAdViews = videoDailyStatistics.getDailyAdViews();
+
+        long videoAdjustment = calculateViewAdjustment(totalViews, dailyViews);
+        long adAdjustment = calculateAdAdjustment(totalViews, dailyAdViews);
+
+        videoDailyStatistics.updateAdjustment(videoAdjustment);
+        videoDailyStatistics.updateAdAdjustment(adAdjustment);
+        videoStatistics.updateAdjustment(videoAdjustment);
+        videoStatistics.updateAdAdjustment(adAdjustment);
+
+        return videoDailyStatistics;
+    }
+
+    private long calculateViewAdjustment(long totalViews, long dailyViews) {
+        long adjustment = 0;
+        if (totalViews < 100_000) {
+            adjustment += Math.min(100_000 - totalViews, dailyViews) * 1;
+            dailyViews -= Math.min(100_000 - totalViews, dailyViews);
+            totalViews = Math.min(100_000, totalViews + dailyViews);
+        }
+        if (totalViews >= 100_000 && totalViews < 500_000 && dailyViews > 0) {
+            adjustment += Math.min(500_000 - totalViews, dailyViews) * 1.1;
+            dailyViews -= Math.min(500_000 - totalViews, dailyViews);
+            totalViews = Math.min(500_000, totalViews + dailyViews);
+        }
+        if (totalViews >= 500_000 && totalViews < 1_000_000 && dailyViews > 0) {
+            adjustment += Math.min(1_000_000 - totalViews, dailyViews) * 1.3;
+            dailyViews -= Math.min(1_000_000 - totalViews, dailyViews);
+            totalViews = Math.min(1_000_000, totalViews + dailyViews);
+        }
+        if (totalViews >= 1_000_000 && dailyViews > 0) {
+            adjustment += dailyViews * 1.5;
+        }
+        return (long) Math.floor(adjustment);
+    }
+
+    private long calculateAdAdjustment(long totalViews, long dailyAdViews) {
+        long adjustment = 0;
+        if (totalViews < 100_000) {
+            adjustment += Math.min(100_000 - totalViews, dailyAdViews) * 10;
+            dailyAdViews -= Math.min(100_000 - totalViews, dailyAdViews);
+            totalViews = Math.min(100_000, totalViews + dailyAdViews);
+        }
+        if (totalViews >= 100_000 && totalViews < 500_000 && dailyAdViews > 0) {
+            adjustment += Math.min(500_000 - totalViews, dailyAdViews) * 12;
+            dailyAdViews -= Math.min(500_000 - totalViews, dailyAdViews);
+            totalViews = Math.min(500_000, totalViews + dailyAdViews);
+        }
+        if (totalViews >= 500_000 && totalViews < 1_000_000 && dailyAdViews > 0) {
+            adjustment += Math.min(1_000_000 - totalViews, dailyAdViews) * 15;
+            dailyAdViews -= Math.min(1_000_000 - totalViews, dailyAdViews);
+            totalViews = Math.min(1_000_000, totalViews + dailyAdViews);
+        }
+        if (totalViews >= 1_000_000 && dailyAdViews > 0) {
+            adjustment += dailyAdViews * 20;
+        }
+        return (long) Math.floor(adjustment);
+    }
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/processor/VideoDailyStatisticsProcessor.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/processor/VideoDailyStatisticsProcessor.java
@@ -1,0 +1,27 @@
+package org.streaming.revenuemanagement.domain.adjustment.batch.processor;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+import org.streaming.revenuemanagement.domain.videodailystatistics.entity.VideoDailyStatistics;
+import org.streaming.revenuemanagement.domain.videostatistics.entity.VideoStatistics;
+import org.streaming.revenuemanagement.domain.videostatistics.repository.VideoStatisticsRepository;
+
+@Component
+@RequiredArgsConstructor
+public class VideoDailyStatisticsProcessor implements ItemProcessor<VideoDailyStatistics, VideoStatistics> {
+
+    private final VideoStatisticsRepository videoStatisticsRepository;
+
+    @Override
+    public VideoStatistics process(VideoDailyStatistics videoDailyStatistics) throws Exception {
+        VideoStatistics videoStatistics = videoStatisticsRepository.findById(videoDailyStatistics.getVideoStatistics().getId())
+                .orElseThrow();
+        videoStatistics.updateStatistics(
+                videoDailyStatistics.getDailyViews(),
+                videoDailyStatistics.getDailyAdViews(),
+                videoDailyStatistics.getDailyPlayTime()
+        );
+        return videoStatistics;
+    }
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/processor/VideoLogStatisticsProcessor.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/processor/VideoLogStatisticsProcessor.java
@@ -1,0 +1,32 @@
+package org.streaming.revenuemanagement.domain.adjustment.batch.processor;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+import org.streaming.revenuemanagement.domain.videodailystatistics.entity.VideoDailyStatistics;
+import org.streaming.revenuemanagement.domain.videodailystatistics.repository.VideoDailyStatisticsRepository;
+import org.streaming.revenuemanagement.domain.videolog.entity.VideoLog;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VideoLogStatisticsProcessor implements ItemProcessor<VideoLog, VideoDailyStatistics> {
+
+    private final VideoDailyStatisticsRepository videoDailyStatisticsRepository;
+
+    @Override
+    public VideoDailyStatistics process(VideoLog videoLog) throws Exception {
+        Long videoId = videoLog.getVideo().getId();
+        log.info("Processing log for Video ID {}: Ad Count {}, Play Time {}", videoId, videoLog.getAdCnt(), videoLog.getPlayTime());
+
+        // 현재 비디오 ID에 해당하는 VideoDailyStatistics 조회 또는 새로 생성
+        VideoDailyStatistics videoDailyStatistics = videoDailyStatisticsRepository.findByVideoId(videoId)
+                .orElseGet(() -> VideoDailyStatistics.builder().videoId(videoId).build());
+
+        // 현재 VideoLog의 정보를 기반으로 VideoDailyStatistics 업데이트
+        videoDailyStatistics.updateStatistics(1L, Long.valueOf(videoLog.getAdCnt()), videoLog.getPlayTime());
+
+        return videoDailyStatistics;
+    }
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/processor/VideoStatisticsProcessor.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/processor/VideoStatisticsProcessor.java
@@ -1,0 +1,20 @@
+package org.streaming.revenuemanagement.domain.adjustment.batch.processor;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+import org.streaming.revenuemanagement.domain.videodailystatistics.entity.VideoDailyStatistics;
+import org.streaming.revenuemanagement.domain.videostatistics.entity.VideoStatistics;
+
+@Component
+@RequiredArgsConstructor
+public class VideoStatisticsProcessor implements ItemProcessor<VideoStatistics, VideoDailyStatistics> {
+
+    @Override
+    public VideoDailyStatistics process(VideoStatistics videoStatistics) throws Exception {
+        return VideoDailyStatistics.builder()
+                .videoStatistics(videoStatistics)
+                .videoId(videoStatistics.getVideo().getId())
+                .build();
+    }
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/reader/AdjustmentVideoDailyStatisticsReader.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/reader/AdjustmentVideoDailyStatisticsReader.java
@@ -1,0 +1,36 @@
+package org.streaming.revenuemanagement.domain.adjustment.batch.reader;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+import org.streaming.revenuemanagement.domain.videodailystatistics.entity.VideoDailyStatistics;
+import org.streaming.revenuemanagement.domain.videodailystatistics.repository.VideoDailyStatisticsRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class AdjustmentVideoDailyStatisticsReader {
+
+    private final VideoDailyStatisticsRepository videoDailyStatisticsRepository;
+
+    public RepositoryItemReader<VideoDailyStatistics> reader(int chunkSize) {
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+        return new RepositoryItemReaderBuilder<VideoDailyStatistics>()
+                .name("adjustmentVideoDailyStatisticsReader")
+                .arguments(List.of(startOfDay, endOfDay))
+                .pageSize(chunkSize)
+                .methodName("findAllByCreatedAtBetween")
+                .repository(videoDailyStatisticsRepository)
+                .sorts(Map.of("id", Sort.Direction.ASC))
+                .build();
+    }
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/reader/VideoDailyStatisticsReader.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/reader/VideoDailyStatisticsReader.java
@@ -1,0 +1,35 @@
+package org.streaming.revenuemanagement.domain.adjustment.batch.reader;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+import org.streaming.revenuemanagement.domain.videodailystatistics.entity.VideoDailyStatistics;
+import org.streaming.revenuemanagement.domain.videodailystatistics.repository.VideoDailyStatisticsRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class VideoDailyStatisticsReader {
+    private final VideoDailyStatisticsRepository videoDailyStatisticsRepository;
+
+    public RepositoryItemReader<VideoDailyStatistics> reader(int chunkSize) {
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+        return new RepositoryItemReaderBuilder<VideoDailyStatistics>()
+                .name("videoDailyStatisticsReader")
+                .arguments(List.of(startOfDay, endOfDay))
+                .pageSize(chunkSize)
+                .methodName("findAllByCreatedAtBetween")
+                .repository(videoDailyStatisticsRepository)
+                .sorts(Map.of("id", Sort.Direction.ASC))
+                .build();
+    }
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/reader/VideoLogPartitionReader.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/reader/VideoLogPartitionReader.java
@@ -1,0 +1,41 @@
+package org.streaming.revenuemanagement.domain.adjustment.batch.reader;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+import org.streaming.revenuemanagement.domain.videolog.entity.VideoLog;
+import org.streaming.revenuemanagement.domain.videolog.repository.VideoLogRepository;
+
+import java.util.Arrays;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VideoLogPartitionReader {
+
+    private final VideoLogRepository videoLogRepository;
+
+    @Bean
+    @StepScope
+    public RepositoryItemReader<VideoLog> videoLogPartitionReaderMethod(
+            @Value("#{stepExecutionContext['minId']}") Long minId,
+            @Value("#{stepExecutionContext['maxId']}") Long maxId,
+            @Value("${spring.batch.chunk.size}") Integer chunkSize) {
+
+        return new RepositoryItemReaderBuilder<VideoLog>()
+                .name("videoLogPartitionReader")
+                .repository(videoLogRepository)
+                .methodName("findVideoLogsByVideoIdRangeAndDateRange")
+                .arguments(Arrays.asList(minId, maxId))
+                .sorts(Map.of("id", Sort.Direction.ASC)) // 여기에 정렬 조건 추가
+                .pageSize(chunkSize)
+                .build();
+    }
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/reader/VideoLogReader.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/reader/VideoLogReader.java
@@ -1,0 +1,42 @@
+//package org.streaming.revenuemanagement.domain.adjustment.batch.reader;
+//
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.batch.core.configuration.annotation.StepScope;
+//import org.springframework.batch.item.data.RepositoryItemReader;
+//import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.data.domain.Sort;
+//import org.springframework.stereotype.Component;
+//import org.streaming.revenuemanagement.domain.videolog.entity.VideoLog;
+//import org.streaming.revenuemanagement.domain.videolog.repository.VideoLogRepository;
+//
+//import java.time.LocalDateTime;
+//import java.util.Arrays;
+//import java.util.Map;
+//
+//@Slf4j
+//@Component
+//@RequiredArgsConstructor
+//public class VideoLogReader {
+//
+//    private final VideoLogRepository videoLogRepository;
+//
+//    @Bean
+//    @StepScope
+//    public RepositoryItemReader<VideoLog> reader(
+//            @Value("#{jobParameters['startDate']}") LocalDateTime start,
+//            @Value("#{jobParameters['endDate']}") LocalDateTime end,
+//            @Value("${spring.batch.chunk.size}") Integer chunkSize) {
+//
+//        return new RepositoryItemReaderBuilder<VideoLog>()
+//                .name("videoLogReader")
+//                .repository(videoLogRepository)
+//                .methodName("findVideoLogsByDateRange") // 전체 범위 데이터를 가져오는 메서드 사용
+//                .arguments(Arrays.asList(start, end))
+//                .sorts(Map.of("id", Sort.Direction.ASC)) // 정렬 조건 추가
+//                .pageSize(chunkSize)
+//                .build();
+//    }
+//}

--- a/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/reader/VideoStatisticsReader.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/reader/VideoStatisticsReader.java
@@ -1,0 +1,29 @@
+package org.streaming.revenuemanagement.domain.adjustment.batch.reader;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+import org.streaming.revenuemanagement.domain.videostatistics.entity.VideoStatistics;
+import org.streaming.revenuemanagement.domain.videostatistics.repository.VideoStatisticsRepository;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class VideoStatisticsReader {
+    private final VideoStatisticsRepository videoStatisticsRepository;
+
+    public RepositoryItemReader<VideoStatistics> reader(int chunkSize) {
+        return new RepositoryItemReaderBuilder<VideoStatistics>()
+                .name("videoStatisticsReader")
+                .arguments(List.of())
+                .pageSize(chunkSize)
+                .methodName("findAll")
+                .repository(videoStatisticsRepository)
+                .sorts(Map.of("id", Sort.Direction.ASC))
+                .build();
+    }
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/writer/AdjustmentVideoDailyStatisticsWriter.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/writer/AdjustmentVideoDailyStatisticsWriter.java
@@ -1,0 +1,37 @@
+package org.streaming.revenuemanagement.domain.adjustment.batch.writer;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.streaming.revenuemanagement.domain.videodailystatistics.entity.VideoDailyStatistics;
+import org.streaming.revenuemanagement.domain.videodailystatistics.repository.VideoDailyStatisticsRepository;
+import org.streaming.revenuemanagement.domain.videostatistics.entity.VideoStatistics;
+import org.streaming.revenuemanagement.domain.videostatistics.repository.VideoStatisticsRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AdjustmentVideoDailyStatisticsWriter implements ItemWriter<VideoDailyStatistics> {
+
+    private final VideoDailyStatisticsRepository videoDailyStatisticsRepository;
+    private final VideoStatisticsRepository videoStatisticsRepository;
+
+    @Transactional
+    @Override
+    public void write(Chunk<? extends VideoDailyStatistics> chunk) throws Exception {
+        List<VideoDailyStatistics> updatedVideoDailyStatistics = new ArrayList<>();
+        List<VideoStatistics> updatedVideoStatistics = new ArrayList<>();
+
+        for (VideoDailyStatistics dailyStatistics : chunk) {
+            updatedVideoDailyStatistics.add(dailyStatistics);
+            VideoStatistics videoStatistics = dailyStatistics.getVideoStatistics();
+            updatedVideoStatistics.add(videoStatistics);
+        }
+        videoDailyStatisticsRepository.saveAll(updatedVideoDailyStatistics);
+        videoStatisticsRepository.saveAll(updatedVideoStatistics);
+    }
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/writer/VideoDailyStatisticsWriter.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/writer/VideoDailyStatisticsWriter.java
@@ -1,0 +1,20 @@
+package org.streaming.revenuemanagement.domain.adjustment.batch.writer;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+import org.streaming.revenuemanagement.domain.videodailystatistics.entity.VideoDailyStatistics;
+import org.streaming.revenuemanagement.domain.videodailystatistics.repository.VideoDailyStatisticsRepository;
+
+@Component
+@RequiredArgsConstructor
+public class VideoDailyStatisticsWriter implements ItemWriter<VideoDailyStatistics> {
+
+    private final VideoDailyStatisticsRepository videoDailyStatisticsRepository;
+
+    @Override
+    public void write(Chunk<? extends VideoDailyStatistics> chunk) throws Exception {
+        videoDailyStatisticsRepository.saveAll(chunk);
+    }
+}

--- a/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/writer/VideoStatisticsWriter.java
+++ b/src/main/java/org/streaming/revenuemanagement/domain/adjustment/batch/writer/VideoStatisticsWriter.java
@@ -1,0 +1,20 @@
+package org.streaming.revenuemanagement.domain.adjustment.batch.writer;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+import org.streaming.revenuemanagement.domain.videostatistics.entity.VideoStatistics;
+import org.streaming.revenuemanagement.domain.videostatistics.repository.VideoStatisticsRepository;
+
+@Component
+@RequiredArgsConstructor
+public class VideoStatisticsWriter implements ItemWriter<VideoStatistics> {
+
+    private final VideoStatisticsRepository videoStatisticsRepository;
+
+    @Override
+    public void write(Chunk<? extends VideoStatistics> chunk) throws Exception {
+        videoStatisticsRepository.saveAll(chunk);
+    }
+}


### PR DESCRIPTION
- 배치 코드의 reader, processor, writer 각각 분리하였습니다

- 배치 파티셔닝 적용하였습니다
  - 파티셔닝 적용 후, 실행시간이 50% 넘게 감소하였습니다.

- 기존에는 videoId를 기준으로 모든 videoStatistics들을 가져와 videoLog 데이터를 count 및 sum 연산 써서 데이터 합산해서 업데이트 해주었었습니다. 파티셔닝 적용하기 위해 videoLogId를 기준으로 모든 로그 데이터들을 가져와서 연산하게 해주었습니다.
  - 기존 방식으로는 파티셔닝이 제대로 적용되지 않았습니다.